### PR TITLE
Migrate to GTK3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+push_to_talk.egg-info
+build
+dist

--- a/push_to_talk_app/application.py
+++ b/push_to_talk_app/application.py
@@ -26,18 +26,20 @@ from optparse import OptionParser
 import os
 import os.path
 
-from gi.repository import GObject, Gio, GLib
-import gtk
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import GObject, Gio, GLib, Gtk as gtk
 
 from interfaces import SkypeInterface, PulseAudioInterface
 from key_monitor import KeyMonitor
 
+
 class PushToTalk(gtk.StatusIcon):
     INTERVAL = 100
     INTERFACES = [
-            PulseAudioInterface,
-            SkypeInterface,
-            ]
+        PulseAudioInterface,
+        SkypeInterface,
+    ]
 
     def __init__(self):
         self.logger = logging.getLogger('push_to_talk_app')
@@ -50,7 +52,7 @@ class PushToTalk(gtk.StatusIcon):
         self.audio_interface = saved_interface if saved_interface else self.INTERFACES[0]
 
         self.do_setup_menu()
-        
+
         self.reset_ui()
         self.set_visible(True)
         self.start()
@@ -68,7 +70,8 @@ class PushToTalk(gtk.StatusIcon):
                     unpacked.append(application_name)
                     updated = GLib.Variant('as', unpacked)
                     settings.set_value(key, updated)
-                    raise Exception("You must log-out and log-in again for your system tray icon to appear.")
+                    raise Exception(
+                        "You must log-out and log-in again for your system tray icon to appear.")
 
     def get_saved_interface(self):
         try:
@@ -83,8 +86,8 @@ class PushToTalk(gtk.StatusIcon):
     @property
     def preferences_file(self):
         return os.path.expanduser(
-                    "~/.push_to_talk_saved",
-                )
+            "~/.push_to_talk_saved",
+        )
 
     def get_saved_interface_name(self):
         with open(self.preferences_file, "r") as infile:
@@ -98,11 +101,11 @@ class PushToTalk(gtk.StatusIcon):
 
     def process(self, pipe, return_pipe):
         monitor = KeyMonitor(
-                self.audio_interface(), 
-                pipe,
-                return_pipe,
-                test=False
-            )
+            self.audio_interface(),
+            pipe,
+            return_pipe,
+            test=False
+        )
         monitor.start()
 
     def read_incoming_pipe(self):
@@ -120,24 +123,24 @@ class PushToTalk(gtk.StatusIcon):
 
     def reset_ui(self):
         self.set_from_file(os.path.join(
-                os.path.dirname(__file__),
-                'icons/mute.png'
-            ))
-        self.set_tooltip('Microphone Muted')
+            os.path.dirname(__file__),
+            'icons/mute.png'
+        ))
+        self.set_tooltip_text('Microphone Muted')
 
     def set_ui_talk(self):
         self.set_from_file(os.path.join(
-                os.path.dirname(__file__),
-                'icons/talk.png'
-            ))
-        self.set_tooltip('Microphone Active')
+            os.path.dirname(__file__),
+            'icons/talk.png'
+        ))
+        self.set_tooltip_text('Microphone Active')
 
     def set_ui_setkey(self):
         self.set_from_file(os.path.join(
-                os.path.dirname(__file__),
-                'icons/setkey.png'
-            ))
-        self.set_tooltip('Please press a key...')
+            os.path.dirname(__file__),
+            'icons/setkey.png'
+        ))
+        self.set_tooltip_text('Please press a key...')
 
     def reset_process(self):
         self.logger.debug("Killing process...")
@@ -149,9 +152,9 @@ class PushToTalk(gtk.StatusIcon):
         self.return_pipe = Queue()
 
         self.p = Process(
-                target=self.process,
-                args=(self.pipe, self.return_pipe, )
-            )
+            target=self.process,
+            args=(self.pipe, self.return_pipe, )
+        )
         self.p.start()
 
         self.logger.debug("Process spawned")
@@ -177,34 +180,34 @@ class PushToTalk(gtk.StatusIcon):
         xml_strings = {}
         for interface in self.INTERFACES:
             xml_strings[interface.verb] = "<menuitem action=\"%s\" />" % (
-                                interface.verb,
-                            )
+                interface.verb,
+            )
         return xml_strings
 
     def do_setup_menu(self):
         verbs = [(
-                'Menu',
+            'Menu',
+            None,
+            'Menu',
+        ),
+            (
+                'SetKey',
                 None,
-                'Menu', 
-                ),
-                (
-                'SetKey', 
-                None, 
-                'Set Key', 
-                None, 
-                'Set key to use for push-to-talk', 
-                self.set_key, 
-            ),]
+                'Set Key',
+                None,
+                'Set key to use for push-to-talk',
+                self.set_key,
+        ), ]
         for interface in self.INTERFACES:
             if self.audio_interface.verb != interface.verb:
                 verbs.append((
-                                interface.verb, 
-                                None, 
-                                interface.verb, 
-                                None, 
-                                '', 
-                                self.change_interface, 
-                        ),)
+                    interface.verb,
+                    None,
+                    interface.verb,
+                    None,
+                    '',
+                    self.change_interface,
+                ),)
 
         action_group = gtk.ActionGroup('Actions')
         action_group.add_actions(verbs)
@@ -212,11 +215,12 @@ class PushToTalk(gtk.StatusIcon):
         self.manager = gtk.UIManager()
         self.manager.insert_action_group(action_group, 0)
         self.manager.add_ui_from_string(self.menu_xml)
-        self.menu = self.manager.get_widget('/Menubar/Menu/SetKey').props.parent
+        self.menu = self.manager.get_widget(
+            '/Menubar/Menu/SetKey').props.parent
         self.connect('popup-menu', self.on_popup_menu)
 
     def on_popup_menu(self, status, button, time):
-        self.menu.popup(None, None, None, button, time)
+        self.menu.popup(None, None, None, None, button, time)
 
     @property
     def menu_xml(self):
@@ -239,14 +243,16 @@ class PushToTalk(gtk.StatusIcon):
         self.logger.debug(final_xml)
         return final_xml
 
+
 def run_from_cmdline():
     parser = OptionParser()
-    parser.add_option('-v', '--verbose', dest='verbose', action='store_true', default=False)
+    parser.add_option('-v', '--verbose', dest='verbose',
+                      action='store_true', default=False)
     (opts, args, ) = parser.parse_args()
 
     logging.basicConfig(
-            level=logging.DEBUG if opts.verbose else logging.WARNING
-        )
+        level=logging.DEBUG if opts.verbose else logging.WARNING
+    )
 
     PushToTalk()
     gtk.main()


### PR DESCRIPTION
This fixes the application for modern Python installations, making it use GTK3.
It also includes some syntax linter changes (PEP-8)
Add `.gitignore`
